### PR TITLE
Added time shift parameter

### DIFF
--- a/transition.lua
+++ b/transition.lua
@@ -208,6 +208,7 @@ lib.to = function( targetObject, transitionParams )
 		tween._duration = transitionParams.time or 500
 		tween.iterations = transitionParams.iterations or 1
 		tween.tag = transitionParams.tag or ""
+		tween._timeShift = transitionParams.timeShift or 0
 		tween._lastPausedTime = nil
 		tween._transition = transitionParams.transition or easing.linear
 		tween._onStart = Runtime.verifyListener( transitionParams.onStart, "onStart" )
@@ -577,7 +578,11 @@ function lib:enterFrame ( event )
 				delay = nil
 			end
 
-			if not delay then
+			-- define if object needs a single transition execution even if delayed
+			tween.needOneExecEvenIfDelayed = tween.needOneExecEvenIfDelayed == nil and delay ~= nil and delay > 0 and tween._timeShift ~= 0
+
+			if not delay or tween.needOneExecEvenIfDelayed then
+				tween.needOneExecEvenIfDelayed = false
 				local params = tween._delayParams
 				if params then
 					lib._initTween( tween, params )
@@ -586,7 +591,7 @@ function lib:enterFrame ( event )
 
 				local target = tween._target
 				local keysFinish = tween._keysFinish
-				local t = currentTime - tween._timeStart
+				local t = currentTime - tween._timeStart + tween._timeShift
 				if t < 0 then t = 0 end
 				local tMax = tween._duration
 				if t < tMax then
@@ -823,6 +828,7 @@ lib.blink = function( targetObject, params )
 	local actionOnRepeat = paramsTable.onRepeat or nil
 	local actionTag = paramsTable.tag or nil
 	local actionTime = actionTime or 500
+	local actionTimeShift = paramsTable.timeShift or nil
 
 	local addedTransition = lib.to( targetObject,
 	{
@@ -837,7 +843,8 @@ lib.blink = function( targetObject, params )
 		onStart = actionOnStart,
 		onRepeat = actionOnRepeat,
 		alpha = 0,
-		tag = actionTag
+		tag = actionTag,
+		timeShift = actionTimeShift,
 	} )
 		--local addedTransition = lib.to( targetObject, { time = actionTime * 0.5, alpha = 0, transition="continuousLoop", iterations = -1 } )
 
@@ -876,6 +883,7 @@ lib.moveTo = function( targetObject, params )
 		local actionTag = paramsTable.tag or nil
 		local actionX = paramsTable.x or nil
 		local actionY = paramsTable.y or nil
+		local actionTimeShift = paramsTable.timeShift or nil
 
 		addedTransition = lib.to( targetObject,
 		{
@@ -893,7 +901,8 @@ lib.moveTo = function( targetObject, params )
 			yScale = actionYScale,
 			x = actionX,
 			y = actionY,
-			tag = actionTag
+			tag = actionTag,
+			timeShift = actionTimeShift,
 		} )
 
 	end
@@ -933,6 +942,7 @@ lib.moveBy = function( targetObject, params )
 		local actionTag = paramsTable.tag or nil
 		local actionX = paramsTable.x or 0
 		local actionY = paramsTable.y or 0
+		local actionTimeShift = paramsTable.timeShift or nil
 
 		addedTransition = lib.to( targetObject,
 		{
@@ -950,7 +960,8 @@ lib.moveBy = function( targetObject, params )
 			yScale = actionYScale,
 			x = targetObject.x + actionX,
 			y = targetObject.y + actionY,
-			tag = actionTag
+			tag = actionTag,
+			timeShift = actionTimeShift,
 		} )
 
 	end
@@ -990,6 +1001,7 @@ lib.scaleTo = function( targetObject, params )
 		local actionX = paramsTable.x or nil
 		local actionY = paramsTable.y or nil
 		local actionTag = paramsTable.tag or nil
+		local actionTimeShift = paramsTable.timeShift or nil
 
 		addedTransition = lib.to( targetObject,
 		{
@@ -1007,7 +1019,8 @@ lib.scaleTo = function( targetObject, params )
 			yScale = actionYScale,
 			x = actionX,
 			y = actionY,
-			tag = actionTag
+			tag = actionTag,
+			timeShift = actionTimeShift,
 		} )
 
 	end
@@ -1047,6 +1060,7 @@ lib.scaleBy = function( targetObject, params )
 		local actionX = paramsTable.x or nil
 		local actionY = paramsTable.y or nil
 		local actionTag = paramsTable.tag or nil
+		local actionTimeShift = paramsTable.timeShift or nil
 
 		addedTransition = lib.to( targetObject,
 		{
@@ -1064,7 +1078,8 @@ lib.scaleBy = function( targetObject, params )
 			alpha = actionAlpha,
 			xScale = targetObject.xScale + actionXScale,
 			yScale = targetObject.yScale + actionYScale,
-			tag = actionTag
+			tag = actionTag,
+			timeShift = actionTimeShift,
 		} )
 
 	end
@@ -1101,6 +1116,7 @@ lib.fadeIn = function( targetObject, params )
 		local actionX = paramsTable.x or nil
 		local actionY = paramsTable.y or nil
 		local actionTag = paramsTable.tag or nil
+		local actionTimeShift = paramsTable.timeShift or nil
 
 		addedTransition = lib.to( targetObject,
 		{
@@ -1116,7 +1132,8 @@ lib.fadeIn = function( targetObject, params )
 			x = actionX,
 			y = actionY,
 			alpha = 1.0,
-			tag = actionTag
+			tag = actionTag,
+			timeShift = actionTimeShift,
 		} )
 
 	end
@@ -1153,6 +1170,7 @@ lib.fadeOut = function( targetObject, params )
 		local actionX = paramsTable.x or nil
 		local actionY = paramsTable.y or nil
 		local actionTag = paramsTable.tag or nil
+		local actionTimeShift = paramsTable.timeShift or nil
 
 		addedTransition = lib.to( targetObject,
 		{
@@ -1168,7 +1186,8 @@ lib.fadeOut = function( targetObject, params )
 			tag = actionTag,
 			x = actionX,
 			y = actionY,
-			alpha = 0.0
+			alpha = 0.0,
+			timeShift = actionTimeShift,
 		} )
 
 	end

--- a/transition.lua
+++ b/transition.lua
@@ -609,7 +609,7 @@ function lib:enterFrame ( event )
 					end
 				else
 					-- the easing function easing.continuousLoop with infinite iterations cannot set the object keys to the finish values.
-					-- also, the last iteration of a transition with easing.continousLoop has to return the object to the start properties,
+					-- also, the last iteration of a transition with easing.continuousLoop has to return the object to the start properties,
 					-- not to the end ones.
 					if tween._transition == easing.continuousLoop or tween._isLoop then
 						if tween.iterations == 1 then
@@ -854,6 +854,51 @@ lib.blink = function( targetObject, params )
 		tag = actionTag
 	} )
 		--local addedTransition = lib.to( targetObject, { time = actionTime * 0.5, alpha = 0, transition="continuousLoop", iterations = -1 } )
+
+	return addedTransition
+
+end
+
+-----------------------------------------------------------------------------------------
+-- blinkContinuous( targetObject, actionDuration )
+-- blinks the targetObject with the transition duration actionDuration with continuous alpha-channel changes
+-----------------------------------------------------------------------------------------
+lib.blinkContinuous = function( targetObject, params )
+	if targetObject == nil then
+		if lib.debugEnabled then
+			error( DEBUG_STRING .. " you have to pass a target object to a transition.blinkContinuous call." )
+		end
+	end
+
+	local paramsTable = params or {}
+
+	local actionTime = paramsTable.time or 500
+	local actionDelay = paramsTable.delay or 0
+	local actionEasing = paramsTable.transition or easing.linear
+	local actionOnComplete = paramsTable.onComplete or nil
+	local actionOnPause = paramsTable.onPause or nil
+	local actionOnResume = paramsTable.onResume or nil
+	local actionOnCancel = paramsTable.onCancel or nil
+	local actionOnStart = paramsTable.onStart or nil
+	local actionOnRepeat = paramsTable.onRepeat or nil
+	local actionTag = paramsTable.tag or nil
+	local actionTime = actionTime or 500
+
+	local addedTransition = lib.to( targetObject,
+	{
+		delay = actionDelay,
+		time = actionTime * 0.5,
+		transition = easing.continuousLoop,
+		iterations = -1,
+		onComplete = actionOnComplete,
+		onPause = actionOnPause,
+		onResume = actionOnResume,
+		onCancel = actionOnCancel,
+		onStart = actionOnStart,
+		onRepeat = actionOnRepeat,
+		alpha = 0,
+		tag = actionTag
+	} )
 
 	return addedTransition
 

--- a/unit_test/main.lua
+++ b/unit_test/main.lua
@@ -51,6 +51,14 @@ r2:setFillColor( 0, 255, 0)
 r1.onComplete = onComplete
 r2.onComplete = onComplete
 
+local r3 = display.newRect( 1, 2*h, w, h )
+r3:setFillColor( 0, 0, 255 )
+transitionNew.blink( r3, { time = 3000 } )
+
+local r4 = display.newRect( 2 * w, 2 * h, w, h )
+r4:setFillColor( 0, 0, 255 )
+transitionNew.blinkContinuous( r4, { time = 3000 } )
+
 function touchHandler (event)
 	if (event.phase == "began") then
 		transitionNew.cancel( event.target.t )

--- a/unit_test/main.lua
+++ b/unit_test/main.lua
@@ -101,7 +101,8 @@ for i = 1, count do
 	r_i.anchorY = 1
 
 	-- example of shifted transition with delay
-	transitionNew.scaleTo(r_i, {yScale = 10, time = 10000, timeShift = i * 10000/count, transition = easing.outInBounce, delay = 3000})
+	r_i.i = i
+	transitionNew.scaleTo(r_i, {yScale = 10, time = 10000, timeShift = i * 10000/count, transition = easing.outInBounce, delay = 3000, onPause = function(obj) print("paused " .. obj.i) end})
 	
 	r_i:setFillColor(0, (i%2 == 1 and 0 or 1), (i%2 == 0 and 0 or 1))
 	arr_r[#arr_r+1] = r_i

--- a/unit_test/main.lua
+++ b/unit_test/main.lua
@@ -25,11 +25,14 @@ package.preload.transition = nil
 
 -------------------------------------------------------------------------------
 
+local W = display.contentWidth
+local H = display.contentHeight
+
 local isPause = false
 local transitionNew = require("transition")
 
-local w = 0.5*display.contentWidth
-local h = 0.5*display.contentHeight
+local w = 0.5*W
+local h = 0.25*H
 local r1 = display.newRect(1,1, w, h)
 r1:setFillColor(255,0,0)
 local executions = 0
@@ -54,7 +57,7 @@ r2.onComplete = onComplete
 function touchHandler (event)
 	if (event.phase == "began") then
 		transitionNew.cancel( event.target.t )
-		print( "Cancelled!")
+		print( "Rect cancelled!")
 	end
 end
 
@@ -62,11 +65,11 @@ function touchHandlerPause (event)
 	if (event.phase == "began") then
 		if false == isPause then
 		transitionNew.pause( event.target.t )
-		print( "Paused!" )
+		print( "Rect paused!" )
 		isPause = true
 		elseif true == isPause then
 		transitionNew.resume ( event.target.t )
-		print( "Resumed!" )
+		print( "Rect resumed!" )
 		isPause = false
 		end
 	end
@@ -79,3 +82,40 @@ r2:addEventListener("touch", touchHandlerPause)
 -- it restarts with an increasing delay
 r1:onComplete()
 r2:onComplete()
+
+
+local arr_r = {}
+local isArrPause = false
+local pauseKey = "p"
+local count = 100
+for i = 1, count do
+	local r_i = display.newRect(W/(count+1) * i, H, W/(count+1), 20)
+	r_i.anchorY = 1
+
+	-- example of shifted transition with delay
+	transitionNew.scaleTo(r_i, {yScale = 10, time = 10000, timeShift = i * 10000/count, transition = easing.outInBounce, delay = 3000})
+	
+	r_i:setFillColor(0, (i%2 == 1 and 0 or 1), (i%2 == 0 and 0 or 1))
+	arr_r[#arr_r+1] = r_i
+end
+
+function keuHandlePause(event)
+	if event.keyName == pauseKey and event.phase == "down" then
+		if false == isArrPause then
+			for i = 1, count do
+				transitionNew.pause(arr_r[i])
+			end
+			print( "Array paused!" )
+			isArrPause = true
+		elseif true == isArrPause then
+			for i = 1, count do
+				transitionNew.resume(arr_r[i])
+			end
+			print( "Array resumed!" )
+			isArrPause = false
+		end
+	end
+end
+
+
+Runtime:addEventListener("key", keuHandlePause)


### PR DESCRIPTION
I ran into a problem that the library doesn't have the ability to start the transition from the values of object's properties that were on the transition at the moment t, which can be difficult to calculate, especially if the transition rule is complex (for example, outInBounce).

In my case, it was needed to initialize the scales of objects that approach the player from the horizon and grow up nonlinearly and which have to be between the player and the horizon when scene appears.

So I added a `time shift` parameter to all transitions (except `dissolve`) which defines initial value of object's property when the transition starts.

A short explanation of how `time shift` parameter behaves and interacts with the `delay` parameter in transition with duration `T`:
- if `time shift` > 0 then transition begins with the value of the object's properties that would have been reached by the object by time equals `time shift` with an unmodified transition and lasts for `T - time shift` ms.
- if both are defined and both > 0 then one calculation of object's properties is performed, then it waits for `delay` ms, and then transition continues for `T - time shift` ms.
- if `time shift` < 0 then trasition behaves as if `delay` is defined and equals `|time shift|`.
- if both are defined and `delay` > 0 and `time shift` < 0 then transition waits for `delay + |time shift|` ms and then starts from the initial values of object's property and lasts for `T` ms.

These code changes will not affect any existing projects.