### PR TITLE
Added blinkContinuous function

### DIFF
--- a/transition.lua
+++ b/transition.lua
@@ -609,7 +609,7 @@ function lib:enterFrame ( event )
 					end
 				else
 					-- the easing function easing.continuousLoop with infinite iterations cannot set the object keys to the finish values.
-					-- also, the last iteration of a transition with easing.continousLoop has to return the object to the start properties,
+					-- also, the last iteration of a transition with easing.continuousLoop has to return the object to the start properties,
 					-- not to the end ones.
 					if tween._transition == easing.continuousLoop or tween._isLoop then
 						if tween.iterations == 1 then
@@ -854,6 +854,51 @@ lib.blink = function( targetObject, params )
 		tag = actionTag
 	} )
 		--local addedTransition = lib.to( targetObject, { time = actionTime * 0.5, alpha = 0, transition="continuousLoop", iterations = -1 } )
+
+	return addedTransition
+
+end
+
+-----------------------------------------------------------------------------------------
+-- blinkContinuous( targetObject, actionDuration )
+-- blinks the targetObject with the transition duration actionDuration with continuous alpha-channel changes
+-----------------------------------------------------------------------------------------
+lib.blinkContinuous = function( targetObject, params )
+	if targetObject == nil then
+		if lib.debugEnabled then
+			error( DEBUG_STRING .. " you have to pass a target object to a transition.blinkContinuous call." )
+		end
+	end
+
+	local paramsTable = params or {}
+
+	local actionTime = paramsTable.time or 500
+	local actionDelay = paramsTable.delay or 0
+	local actionEasing = paramsTable.transition or easing.linear
+	local actionOnComplete = paramsTable.onComplete or nil
+	local actionOnPause = paramsTable.onPause or nil
+	local actionOnResume = paramsTable.onResume or nil
+	local actionOnCancel = paramsTable.onCancel or nil
+	local actionOnStart = paramsTable.onStart or nil
+	local actionOnRepeat = paramsTable.onRepeat or nil
+	local actionTag = paramsTable.tag or nil
+	local actionTime = actionTime or 500
+
+	local addedTransition = lib.to( targetObject,
+	{
+		delay = actionDelay,
+		time = actionTime * 0.5,
+		transition = easing.continuousLoop,
+		iterations = -1,
+		onComplete = actionOnComplete,
+		onPause = actionOnPause,
+		onResume = actionOnResume,
+		onCancel = actionOnCancel,
+		onStart = actionOnStart,
+		onRepeat = actionOnRepeat,
+		alpha = 0,
+		tag = actionTag
+	} )
 
 	return addedTransition
 

--- a/unit_test/main.lua
+++ b/unit_test/main.lua
@@ -51,6 +51,14 @@ r2:setFillColor( 0, 255, 0)
 r1.onComplete = onComplete
 r2.onComplete = onComplete
 
+local r3 = display.newRect( 1, 2*h, w, h )
+r3:setFillColor( 0, 0, 255 )
+transitionNew.blink( r3, { time = 3000 } )
+
+local r4 = display.newRect( 2 * w, 2 * h, w, h )
+r4:setFillColor( 0, 0, 255 )
+transitionNew.blinkContinuous( r4, { time = 3000 } )
+
 function touchHandler (event)
 	if (event.phase == "began") then
 		transitionNew.cancel( event.target.t )


### PR DESCRIPTION
In ```transition.blink``` function there is a typo: not existing ```easing.continousLoop``` is used instead of ```easing.contin```**u**```ousLoop```.

This is cause blinked object to fade out smooth and then instant fade in since ```easing.linear``` is used for transition except ```easing.continousLoop``` which is equals to ```nil```.

The bug appeared on September 11, 2013 with the release of version 2.0 of transition framework, when the function itself was added (initially with this error).

I cannot find any topics related to this behaviour on forum neither issue on Github or Discord. Maybe because of this behaviour falls under the definition of "blinking" and doesn`t arise any questions.

Anyway, i doubt this is desired behaviour that developers wanted to implement.

To fix this typo and not affect any of millions existing projects I added a new function ```transition.blinkContinuous``` with correct ```continuousLoop```. 

Here you can see the difference:
![blink_diff](https://user-images.githubusercontent.com/22574956/139540868-f669c42a-313a-4cfe-b9d5-45f3e2ba0b85.gif)
.